### PR TITLE
No uppercase on bible reference

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,7 +24,7 @@ function parseText(text) {
 			// Title
 			slides.push({ title: part[0] ? part[0].toUpperCase() : part[0] });
 		} else {
-			part = { reference: part[0].toUpperCase(), verse: _.slice(_.values(part), 1).join(' ') };
+			part = { reference: part[0], verse: _.slice(_.values(part), 1).join(' ') };
 
 			_.forEach(splitVerses(part.verse), function(verse) {
 				var slide = _.clone(part);

--- a/test/parse-text.test.js
+++ b/test/parse-text.test.js
@@ -93,7 +93,7 @@ describe('parseText', function() {
 			Parser.parseText('Psaltaren 56:9 (SFB15)\n6 Du ha\u030aller ra\u0308kning o\u0308verge dig.')
 		).be.eql([
 			{
-				"reference": "PSALTAREN 56:9 (SFB15)",
+				"reference": "Psaltaren 56:9 (SFB15)",
 				"verse": {
 					"number": "6",
 					"text": `Du håller räkning överge dig.`


### PR DESCRIPTION
If bible reference is preferred not to be uppercase, then it's not forced by the parser.